### PR TITLE
fix: replace characters not allowed in docker tag names

### DIFF
--- a/docker-gpr/main.js
+++ b/docker-gpr/main.js
@@ -19,7 +19,8 @@ const getBranchName = () => {
   if (ref && /\/development|\/master/.test(ref)) {
     return ref.replace('refs/heads/', '');
   } else if (pr_ref && /\/pull\//.test(ref)) {
-    return pr_ref.replace('/', '-');
+    // Replace characters that isn't allowed in a docker tag name
+    return pr_ref.replace(/(^\.)|(^-)|[^A-Za-z0-9-_.]/g, '-').slice(0, 128);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "1.4.5-pr30.0",
+  "version": "1.4.5-pr37.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "1.4.5-pr30.0",
+  "version": "1.4.5-pr37.0",
   "description": "Github packages for Storykit org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
According to [docker documentation](https://docs.docker.com/engine/reference/commandline/tag/#extended-description):
>A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.