### PR TITLE
fix: set HOME env variable for heroku cli

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,9 +1,7 @@
 name: Publish Beta
 
 on:
-  pull_request:
-    branches-ignore:
-      - master
+  workflow_dispatch:
 
 jobs:
   beta-release:

--- a/heroku-docker-release/main.js
+++ b/heroku-docker-release/main.js
@@ -11,6 +11,7 @@ async function loginToHeroku() {
       {
         env: {
           'HEROKU_API_KEY': password,
+          HOME: '.',
         }
       }
     );
@@ -30,6 +31,7 @@ async function pushToHeroku() {
       {
         env: {
           'HEROKU_API_KEY': password,
+          HOME: '.',
         }
       }
     );
@@ -49,6 +51,7 @@ async function releaseToHeroku() {
       {
         env: {
           'HEROKU_API_KEY': password,
+          HOME: '.',
         }
       }
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "github-actions",
-  "version": "1.4.6",
+  "version": "1.4.7-pr46.4",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "1.4.6",
+  "version": "1.4.7-pr46.4",
   "description": "Github packages for Storykit org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Heroku CLI commands failed because the HOME env variable wasn't set. Not sure where this issue came from but this resolves it.

Example of when the action failed: https://github.com/Storykit/scena/actions/runs/799435853