### PR TITLE
fix: NODE_ENV as build arg for heroku docker release

### DIFF
--- a/heroku-docker-release/README.md
+++ b/heroku-docker-release/README.md
@@ -6,6 +6,8 @@ Build and release docker images to heroku.
 Name your docker files according to the formation they are for. For example `Dockerfile.web` formation for `web`.
 See more [here](https://devcenter.heroku.com/articles/container-registry-and-runtime#pushing-multiple-images).
 
+The environment variables `NPM_TOKEN` and `NODE_ENV` are passed as build args to docker.
+
 ## Action Options:
 
 |Parameter|Description|Default Value|Required|

--- a/heroku-docker-release/main.js
+++ b/heroku-docker-release/main.js
@@ -26,7 +26,7 @@ async function pushToHeroku() {
     const appName = getInput("heroku-app-name");
     const formation = getInput("heroku-app-formation");
     await exec(
-      `heroku container:push ${formation} --recursive --app ${appName} --arg NPM_TOKEN=${process.env.NPM_TOKEN}`,
+      `heroku container:push ${formation} --recursive --app ${appName} --arg NPM_TOKEN=${process.env.NPM_TOKEN} --arg NODE_ENV=${process.env.NODE_ENV}`,
       null,
       {
         env: {


### PR DESCRIPTION
Works in the same way as `NPM_TOKEN`. Added a sentence about it in README as well.