### PR TITLE
Use new github container registry

### DIFF
--- a/docker-gpr/docker.js
+++ b/docker-gpr/docker.js
@@ -1,7 +1,7 @@
 const { getInput, debug, setSecret } = require("@actions/core");
 
 const BUILD_ARGS = ['NPM_TOKEN'];
-const containerRegistry = 'docker.pkg.github.com';
+const containerRegistry = 'ghcr.io';
 
 const dockerfileLocation = getInput("dockerfile-location");
 const imageName = getInput("image-name").toLowerCase();


### PR DESCRIPTION
More info why:
https://docs.docker.com/engine/deprecated/#pulling-images-from-non-compliant-image-registries
https://github.blog/2021-06-21-github-packages-container-registry-generally-available/#a-new-home-for-your-docker-containers
https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry