### PR TITLE
fix: allow for args to be empty

### DIFF
--- a/heroku-docker-release/main.js
+++ b/heroku-docker-release/main.js
@@ -34,7 +34,7 @@ async function pushToHeroku() {
       .map(key => `${key}=${process.env[key]}`);
 
     await exec(
-      `heroku container:push ${formation} --recursive --app ${appName} --arg ${args.join(',')}`,
+      `heroku container:push ${formation} --recursive --app ${appName} ${args.length ? '--arg ' + args.join(',') : ''}`,
       null,
       {
         env: {


### PR DESCRIPTION
Fixes so that it wont throw an error when no arguments are present.
> Error: Flag --arg expects a value