### PR TITLE
fix: ability to pass basic pass as build argument to docker file

### DIFF
--- a/heroku-docker-release/main.js
+++ b/heroku-docker-release/main.js
@@ -23,7 +23,8 @@ async function loginToHeroku() {
 async function pushToHeroku() {
   const containerArgs = [
     'NPM_TOKEN',
-    'NODE_ENV'
+    'NODE_ENV',
+    'BASIC_PASS',
   ];
 
   try {


### PR DESCRIPTION
Would have been nice to be able to set the container args as an input to the action but the inputs can only be strings and booleans...